### PR TITLE
Fix ES6 import example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ actioncable-js can be installed using npm:
 
 And included in your ES6+ project with:
 
-`include { ActionCable } from 'actioncable-js'`
+`import { ActionCable } from 'actioncable-js';`
 
 Alternatively, simply include `dist/action_cable.js` in your project.
 


### PR DESCRIPTION
Hello, this corrects the ES6 import statement example.

Thanks for the library--I expect many will soon be searching for solutions like this.
