### PR TITLE
Changing imports loader to work with Webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // global object is required for webpack to compile action_cable.js
-require("imports?this=>global!./dist/action_cable.js")
+require("imports-loader?this=>global!./dist/action_cable.js")
 module.exports = {
   ActionCable: global.ActionCable
 }


### PR DESCRIPTION
From version 2 onwards, [Webpack requires all loaders to be appended with -loader by default](https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed). This PR simply appends `-loader` to the imports loader to allow actioncable-js to work without additional webpack config.